### PR TITLE
Bayesian optimizer: bugfix

### DIFF
--- a/bayes_opt/util.py
+++ b/bayes_opt/util.py
@@ -53,7 +53,7 @@ def acq_max(ac, gp, y_max, bounds, random_state, n_warmup=10000, n_iter=10):
     for x_try in x_seeds:
         # Find the minimum of minus the acquisition function
         res = minimize(lambda x: -ac(x.reshape(1, -1), gp=gp, y_max=y_max),
-                       x_try.reshape(1, -1),
+                       x_try,
                        bounds=bounds,
                        method="L-BFGS-B")
 


### PR DESCRIPTION
The scipy function minimize expects a 1d array, therefore the reshape of `x_try` is not helping.